### PR TITLE
For YAPF only format modified lines by default

### DIFF
--- a/gitlint/__init__.py
+++ b/gitlint/__init__.py
@@ -21,31 +21,34 @@ It supports many filetypes, including:
     among others. See https://github.com/sk-/git-lint for the complete list.
 
 Usage:
-    git-lint [-f | --force] [--json] [--mode=MODE] [--no-cache] [--fix | --fix-all] [FILENAME ...]
-    git-lint [-t | --tracked] [-f | --force] [--json] [--mode=MODE] [--no-cache] [--fix | --fix-all]
+    git-lint [-f | --force] [--json] [--mode=MODE] [--no-cache] [--fix | --fix-all] [--fix-linexp=LINES] [FILENAME ...]
+    git-lint [-t | --tracked] [-f | --force] [--json] [--mode=MODE] [--no-cache] [--fix | --fix-all] [--fix-linexp=LINES]
     git-lint -h | --version
 
 Options:
-    -h             Show the usage patterns.
-    --version      Prints the version number.
-    -f --force     Shows all the lines with problems.
-    -t --tracked   Lints only tracked files in the index.
-    --json         Prints the result as a json string. Useful to use it in
-                   conjunction with other tools.
-    --mode=MODE    [merge-base, local, last-commit] Default is merge-base.
+    -h                  Show the usage patterns.
+    --version           Prints the version number.
+    -f --force          Shows all the lines with problems.
+    -t --tracked        Lints only tracked files in the index.
+    --json              Prints the result as a json string. Useful to use it in
+                        conjunction with other tools.
+    --mode=MODE         [merge-base, local, last-commit] Default is merge-base.
  
-                   merge-base: Checks modifications since the merge-base commit
-                   of this branch with master. Not supported for Mercurial vcs.
+                         merge-base: Checks modifications since the merge-base commit
+                         of this branch with master. Not supported for Mercurial vcs.
                   
-                   local: Checks local modifications (those that have not yet been
-                   committed).
+                         local: Checks local modifications (those that have not yet been
+                         committed).
                   
-                   last-comit: Checks modifications since just prior to the last commit.
-    --no-cache     If set, do not make use of the lint results cache.
-    --fix          If set, run code formatters ('fixers') before linting. Linting will be applied
-                   to changes post-fixing. Formatters that support formatting specific line
-                   ranges in a file will be passed modified line ranges corresponding to the mode.
-    --fix-all      Same as fix, but runs formatting on all lines for all formatters.
+                         last-comit: Checks modifications since just prior to the last commit.
+    --no-cache           If set, do not make use of the lint results cache.
+    --fix                If set, run code formatters ('fixers') before linting. Linting will be applied
+                         to changes post-fixing. Formatters that support formatting specific line
+                         ranges in a file will be passed modified line ranges corresponding to the mode.
+    --fix-linexp=LINES   When --fix is passed, this flag controls the number of lines above and below a
+                         modified line to format. For instance, if line 3 is modified and --fix-linexp=1
+                         then lines 2-4 will be formatted. Defaults to 0. Must be a non-negative integer.
+    --fix-all            Same as fix, but runs formatting on all lines for all formatters.
 """
 
 from __future__ import unicode_literals
@@ -177,8 +180,14 @@ def get_vcs_root():
     return (None, None)
 
 
-def process_file(vcs, commit, force, linter_config, fixer_config, fix, fix_all,
-                 file_data):
+def get_vcs_modified_lines(vcs, force, filename, extra_file_data, commit):
+    if force:
+        return None
+    return vcs.modified_lines(filename, extra_file_data, commit=commit)
+
+
+
+def process_file(vcs, commit, force, linter_config, fixer_config, fix, fix_all, file_data):
     """Lint and optionally fix the file.
 
     Returns:
@@ -186,16 +195,12 @@ def process_file(vcs, commit, force, linter_config, fixer_config, fix, fix_all,
     """
     filename, extra_data = file_data
 
-    if force:
-        modified_lines = None
-    else:
-        modified_lines = vcs.modified_lines(filename, extra_data, commit=commit)
-
     if fix:
-        fixers.fix(filename, fixer_config, modified_lines)
+        fixers.fix(filename, fixer_config, get_vcs_modified_lines(vcs, force, filename, extra_data, commit))
     elif fix_all:
         fixers.fix(filename, fixer_config)
-    result = linters.lint(filename, modified_lines, linter_config)
+    
+    result = linters.lint(filename, get_vcs_modified_lines(vcs, force, filename, extra_data, commit), linter_config)
     result = result[filename]
 
     return filename, result
@@ -267,7 +272,7 @@ def main(argv, stdout=sys.stdout, stderr=sys.stderr):
     files_with_problems = 0
     linter_config = linters.parse_yaml_config(
         config.get('linters', {}), repository_root, not arguments['--no-cache'])
-    fixer_config = fixers.parse_yaml_config(config.get('fixers', {}), repository_root)
+    fixer_config = fixers.parse_yaml_config(config.get('fixers', {}), repository_root, arguments['--fix-linexp'])
     json_result = {}
 
     with futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count())\

--- a/gitlint/configs/config.yaml
+++ b/gitlint/configs/config.yaml
@@ -30,6 +30,9 @@ fixers:
     arguments:
       - --in-place
       - --style={DEFAULT_CONFIGS}/style.yapf
+    # Arguments to be configured at runtime.
+    dynamic_arguments:
+      - --lines={MODIFIED_LINES_RANGE_REPEATED_ARG}
     installation: "Run pip install yapf."
 
   # Javascript

--- a/gitlint/fixers.py
+++ b/gitlint/fixers.py
@@ -1,9 +1,14 @@
 """Functions for invoking a fix command."""
 
 import collections
+import copy
 import os
 
 from gitlint import utils
+
+
+FIX_LINE_EXPANSION_UP = 1
+FIX_LINE_EXPANSION_DOWN = 1
 
 
 def missing_requirements_command(missing_programs, installation_string,
@@ -17,21 +22,42 @@ def missing_requirements_command(missing_programs, installation_string,
            installation_string))
 
 
-def fix_command(name, program, arguments, filename):
+def get_modified_lines_range_tuples(modified_lines):
+    """Returns a list of (modified line range start, modified line range end) tuples."""
+    sorted_lines = sorted(modified_lines)
+    modified_lines_ranges = []
+    range_start = -1
+    range_end = -1
+    sorted_lines_len = len(sorted_lines)
+    for ix, line in enumerate(sorted_lines):
+        if range_start == -1:
+            range_start = max(1, line - FIX_LINE_EXPANSION_UP)
+        elif ix == (sorted_lines_len - 1) or (line - FIX_LINE_EXPANSION_UP) > (range_end + 1):
+            modified_lines_ranges.append((range_start, range_end))
+            range_start = max(1, line - FIX_LINE_EXPANSION_UP)
+        range_end = line + FIX_LINE_EXPANSION_DOWN
+    return modified_lines_ranges
+  
+
+def fix_command(name, program, arguments, dynamic_arguments, filename, lines=None):
     """Executes a fix program."""
-    utils.run(name, program, arguments, False, filename)
+    all_arguments = copy.deepcopy(arguments)
+    for arg in dynamic_arguments:
+        if '{MODIFIED_LINES_RANGE_REPEATED_ARG}' in arg and lines:
+          for start, end in get_modified_lines_range_tuples(lines):
+            all_arguments.append(arg.replace('{MODIFIED_LINES_RANGE_REPEATED_ARG}', '%s-%s' % (start, end)))
+    utils.run(name, program, all_arguments, False, filename)
 
 
 def parse_yaml_config(yaml_config, repo_home):
-    """Converts a dictionary (parsed Yaml) to the internal epresentation."""
+    """Converts a dictionary (parsed Yaml) to the internal representation."""
     config = collections.defaultdict(list)
 
     for name, data in yaml_config.items():
         command = utils.replace_variables([data['command']], repo_home)[0]
         requirements = utils.replace_variables(
             data.get('requirements', []), repo_home)
-        arguments = utils.replace_variables(data.get('arguments', []), repo_home)
-
+    
         not_found_programs = utils.programs_not_in_path([command] +
                                                         requirements)
         if not_found_programs:
@@ -39,21 +65,25 @@ def parse_yaml_config(yaml_config, repo_home):
                                           not_found_programs,
                                           data['installation'])
         else:
-            fixer_command = utils.Partial(fix_command, name, command, arguments)
+            arguments = utils.replace_variables(data.get('arguments', []), repo_home)
+            dynamic_arguments = data.get('dynamic_arguments', [])
+            fixer_command = utils.Partial(fix_command, name, command, arguments, dynamic_arguments)
         for extension in data['extensions']:
             config[extension].append(fixer_command)
 
     return config
 
 
-def fix(filename, config):
+def fix(filename, config, lines=None):
     """Fixes formatting issues in a file.
 
     Args:
         filename: string: filename to fix.
         config: dict[string: fixer]: mapping from extension to a fixer
           function.
+        lines: list[int]|None: list of lines that we want to format. If None,
+          then all lines will be formatted.
     """
     _, ext = os.path.splitext(filename)
     for fixer in config.get(ext, []):
-        fixer(filename)
+        fixer(filename, lines)

--- a/gitlint/fixers.py
+++ b/gitlint/fixers.py
@@ -55,8 +55,8 @@ def fix_command(name, program, arguments, dynamic_arguments, fix_line_exp, filen
     for arg in dynamic_arguments:
         if '{MODIFIED_LINES_RANGE_REPEATED_ARG}' in arg and lines:
           pattern = arg.replace('{MODIFIED_LINES_RANGE_REPEATED_ARG}', '%s-%s')
-          for start, end in get_modified_lines_range_tuples(lines, fix_line_exp):
-            all_arguments.append(pattern % (start, end))
+          all_arguments.extend(
+              [pattern % (start, end) for start, end in get_modified_lines_range_tuples(lines, fix_line_exp)])
     utils.run(name, program, all_arguments, False, filename)
 
 

--- a/gitlint/fixers.py
+++ b/gitlint/fixers.py
@@ -54,8 +54,9 @@ def fix_command(name, program, arguments, dynamic_arguments, fix_line_exp, filen
     all_arguments = copy.deepcopy(arguments)
     for arg in dynamic_arguments:
         if '{MODIFIED_LINES_RANGE_REPEATED_ARG}' in arg and lines:
+          pattern = arg.replace('{MODIFIED_LINES_RANGE_REPEATED_ARG}', '%s-%s')
           for start, end in get_modified_lines_range_tuples(lines, fix_line_exp):
-            all_arguments.append(arg.replace('{MODIFIED_LINES_RANGE_REPEATED_ARG}', '%s-%s' % (start, end)))
+            all_arguments.append(pattern % (start, end))
     utils.run(name, program, all_arguments, False, filename)
 
 


### PR DESCRIPTION
For YAPF only format modified lines by default with configurable line expansion. Also add a fix-all option. Finally, fix a bug that 'modified lines' used for linting should be determined post-formatting.

